### PR TITLE
deps: use egg-init v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "create-egg",
-  "version": "2.0.2",
+  "version": "2.0.1",
   "description": "Alias for egg-init, so you could use `npm init egg showcase`.",
   "dependencies": {
-    "egg-init": "*"
+    "egg-init": "3"
   },
   "devDependencies": {
     "autod": "^3.0.1",
@@ -16,7 +16,7 @@
   },
   "bin": "./bin/create-egg.js",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=16.0.0"
   },
   "scripts": {
     "autod": "autod",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "create-egg",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Alias for egg-init, so you could use `npm init egg showcase`.",
   "dependencies": {
-    "egg-init": "^2"
+    "egg-init": "*"
   },
   "devDependencies": {
     "autod": "^3.0.1",


### PR DESCRIPTION
When running "egg-init", it always checks if there's a newer version available. If there's a newer version, the "init" process is aborted. So we need to install the newest version of "egg-init".

Already tested successfully on my local machine.